### PR TITLE
Add --sizefile metadata option

### DIFF
--- a/FileDiscovery/Directory.cs
+++ b/FileDiscovery/Directory.cs
@@ -70,7 +70,7 @@ namespace SMBeagle.FileDiscovery
             Share = share;
             Path = path;
         }
-        public void FindFilesWindows(List<string> extensionsToIgnore = null)
+        public void FindFilesWindows(List<string> extensionsToIgnore = null, bool includeFileSize = false)
         {
             try
             {
@@ -86,14 +86,15 @@ namespace SMBeagle.FileDiscovery
                             fullName: file.FullName,
                             extension: file.Extension,
                             creationTime: file.CreationTime,
-                            lastWriteTime: file.LastWriteTime
+                            lastWriteTime: file.LastWriteTime,
+                            fileSize: includeFileSize ? file.Length : 0
                         )
                     );
                 }
             }
             catch  {            }
         }
-        public void FindFilesCrossPlatform(List<string> extensionsToIgnore = null)
+        public void FindFilesCrossPlatform(List<string> extensionsToIgnore = null, bool includeFileSize = false)
         {
             try
             {
@@ -131,7 +132,8 @@ namespace SMBeagle.FileDiscovery
                                             fullName: path,
                                             extension: extension,
                                             creationTime: d.CreationTime,
-                                            lastWriteTime: d.LastWriteTime
+                                            lastWriteTime: d.LastWriteTime,
+                                            fileSize: includeFileSize ? (long)d.EndOfFile : 0
                                         )
                                     );
                                 }
@@ -218,17 +220,17 @@ namespace SMBeagle.FileDiscovery
             }
         }
 
-        public void FindFilesRecursively(bool crossPlatform, ref bool abort, List<string> extensionsToIgnore = null)
+        public void FindFilesRecursively(bool crossPlatform, ref bool abort, List<string> extensionsToIgnore = null, bool includeFileSize = false)
         {
             if (crossPlatform)
-                FindFilesCrossPlatform(extensionsToIgnore);
+                FindFilesCrossPlatform(extensionsToIgnore, includeFileSize);
             else
-                FindFilesWindows(extensionsToIgnore);
+                FindFilesWindows(extensionsToIgnore, includeFileSize);
             foreach (Directory dir in RecursiveChildDirectories)
             {
                 if (abort)
                     return;
-                dir.FindFilesRecursively(crossPlatform, ref abort, extensionsToIgnore);
+                dir.FindFilesRecursively(crossPlatform, ref abort, extensionsToIgnore, includeFileSize);
             }
         }
 

--- a/FileDiscovery/File.cs
+++ b/FileDiscovery/File.cs
@@ -11,10 +11,11 @@ namespace SMBeagle.FileDiscovery
         public bool Readable { get; set; }
         public bool Writeable { get; set; }
         public bool Deletable { get; set; }
+        public long FileSize { get; set; }
         public DateTime CreationTime { get; set; }
         public DateTime LastWriteTime { get; set; }
 
-        public File(string name, string fullName, string extension, DateTime creationTime, DateTime lastWriteTime, Directory parentDirectory)
+        public File(string name, string fullName, string extension, DateTime creationTime, DateTime lastWriteTime, Directory parentDirectory, long fileSize = 0)
         {
             Name = name;
             Extension = extension;
@@ -22,6 +23,7 @@ namespace SMBeagle.FileDiscovery
             LastWriteTime = lastWriteTime;
             ParentDirectory = parentDirectory;
             FullName = fullName;
+            FileSize = fileSize;
         }
 
         public void SetPermissions(bool read, bool write, bool delete)

--- a/FileDiscovery/FileFinder.cs
+++ b/FileDiscovery/FileFinder.cs
@@ -46,8 +46,10 @@ namespace SMBeagle.FileDiscovery
             }
         }
 
-        public FileFinder(List<Share> shares, string outputDirectory, bool fetchFiles, List<String> filePatterns, bool getPermissionsForSingleFileInDir = true, bool enumerateAcls = true, bool quiet = false, bool verbose = false, bool crossPlatform = false)
+        bool _includeFileSize;
+        public FileFinder(List<Share> shares, string outputDirectory, bool fetchFiles, List<String> filePatterns, bool getPermissionsForSingleFileInDir = true, bool enumerateAcls = true, bool quiet = false, bool verbose = false, bool crossPlatform = false, bool includeFileSize = false)
         {
+            _includeFileSize = includeFileSize;
             if (fetchFiles)
             {
                 try
@@ -127,7 +129,7 @@ namespace SMBeagle.FileDiscovery
                 abort = false;
                 OutputHelper.WriteLine($"\renumerating files in '{dir.UNCPath}' - CTRL-BREAK or CTRL-PAUSE to SKIP                                          ", 1, false);
                 // TODO: pass in the ignored extensions from the commandline
-                dir.FindFilesRecursively(crossPlatform: crossPlatform, ref abort, extensionsToIgnore: new List<string>() { ".dll",".manifest",".cat" });
+                dir.FindFilesRecursively(crossPlatform: crossPlatform, ref abort, extensionsToIgnore: new List<string>() { ".dll",".manifest",".cat" }, includeFileSize: _includeFileSize);
                 if (verbose)
                     OutputHelper.WriteLine($"\rFound {dir.ChildDirectories.Count} child directories and {dir.RecursiveFiles.Count} files in '{dir.UNCPath}'",2);
                 

--- a/FileDiscovery/Output/FileOutput.cs
+++ b/FileDiscovery/Output/FileOutput.cs
@@ -22,6 +22,7 @@ namespace SMBeagle.FileDiscovery.Output
         public bool Deletable { get; set; }
         public Enums.DirectoryTypeEnum DirectoryType { get; set; }
         public string Base { get; set; }
+        public long FileSize { get; set; }
         public FileOutput(File file)
         {
             Name = file.Name.ToLower();
@@ -35,6 +36,7 @@ namespace SMBeagle.FileDiscovery.Output
             Deletable = file.Deletable;
             DirectoryType = file.ParentDirectory.Base.DirectoryType;
             Base = file.ParentDirectory.Share.uncPath;
+            FileSize = file.FileSize;
         }
     }
 }

--- a/IMPLEMENTATION_REPORT_SIZEFILE.md
+++ b/IMPLEMENTATION_REPORT_SIZEFILE.md
@@ -1,0 +1,20 @@
+# Implementation Report --sizefile
+
+## Modified Files
+- `Program.cs`: added `--sizefile` option and passed to `FileFinder`; added example.
+- `FileDiscovery/File.cs`: added `FileSize` property and constructor parameter.
+- `FileDiscovery/Output/FileOutput.cs`: outputs the new `FileSize` field.
+- `FileDiscovery/Directory.cs`: updated file discovery methods to optionally record file sizes.
+- `FileDiscovery/FileFinder.cs`: accepts a new parameter to propagate the option to directories.
+- `README.md`: documented the new command line flag.
+
+## Testing
+- **Build**: `dotnet build SMBeagle.sln` succeeded.
+- **Help**: `dotnet run -- --help` shows the `--sizefile` option.
+- **Python tests**: attempted `pytest` but failed because required environment variables and services were unavailable in this environment.
+
+## Issues
+- Python integration tests require a special environment with `ROOTDIR` and SMB server setup. These were not available so tests failed.
+
+## Recommendations
+- Future metadata flags can follow the same approach: extend `File` and `FileOutput`, propagate options via `FileFinder` and `Directory`.

--- a/Program.cs
+++ b/Program.cs
@@ -336,6 +336,7 @@ namespace SMBeagle
                     enumerateAcls: !opts.DontEnumerateAcls,
                     verbose: opts.Verbose,
                     crossPlatform: crossPlatform
+                    , includeFileSize: opts.SizeFile
                     );
 
             OutputHelper.WriteLine("7. Completing the writes to CSV or elasticsearch (or both)");
@@ -449,6 +450,9 @@ namespace SMBeagle
             [Option('p', "password", Required = false, HelpText = "Password for connecting to SMB - mandatory on linux")]
             public string Password { get; set; }
 
+            [Option("sizefile", Required = false, HelpText = "Collect file sizes in bytes")]
+            public bool SizeFile { get; set; }
+
             [Usage(ApplicationAlias = "SMBeagle")]
             public static IEnumerable<Example> Examples
             {
@@ -461,6 +465,7 @@ namespace SMBeagle
                     yield return new Example("Output to elasticsearch and CSV", unParserSettings, new Options { ElasticsearchHost = "127.0.0.1", CsvFile = "out.csv" });
                     yield return new Example("Disable network discovery and provide manual networks", unParserSettings, new Options { ElasticsearchHost = "127.0.0.1", DisableNetworkDiscovery = true,  Networks = new List<String>() { "192.168.12.0./23", "192.168.15.0/24" } });
                     yield return new Example("Do not enumerate ACLs (FASTER)", unParserSettings, new Options { ElasticsearchHost = "127.0.0.1", DontEnumerateAcls = true });
+                    yield return new Example("Collect file size metadata", unParserSettings, new Options { ElasticsearchHost = "127.0.0.1", SizeFile = true });
                 }
             }
         }

--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ Do not enumerate ACLs (FASTER):
                                      for SMB Hosts
   -A, --dont-enumerate-acls          (Default: false) Skip enumeration of file
                                      ACLs
+  --sizefile                         Collect file sizes in bytes
   -d, --domain                       (Default: ) Domain for connecting to SMB
   -u, --username                     Username for connecting to SMB - mandatory
                                      on linux


### PR DESCRIPTION
## Summary
- support optional file size collection via `--sizefile`
- propagate file size through discovery and output
- document the new flag
- add report of implementation

## Testing
- `dotnet build SMBeagle.sln`
- `dotnet run -- --help`
- `pytest -q` *(fails: environment missing ROOTDIR and SMB setup)*

------
https://chatgpt.com/codex/tasks/task_e_6851458d2d008320a0cce2a225d22e37