### PR TITLE
Implement --fileattributes option

### DIFF
--- a/FileDiscovery/Directory.cs
+++ b/FileDiscovery/Directory.cs
@@ -71,7 +71,7 @@ namespace SMBeagle.FileDiscovery
             Share = share;
             Path = path;
         }
-        public void FindFilesWindows(List<string> extensionsToIgnore = null, bool includeFileSize = false, bool includeAccessTime = false, bool verbose = false)
+        public void FindFilesWindows(List<string> extensionsToIgnore = null, bool includeFileSize = false, bool includeAccessTime = false, bool includeFileAttributes = false, bool verbose = false)
         {
             try
             {
@@ -91,14 +91,15 @@ namespace SMBeagle.FileDiscovery
                             creationTime: file.CreationTime,
                             lastWriteTime: file.LastWriteTime,
                             fileSize: includeFileSize ? file.Length : 0,
-                            accessTime: includeAccessTime ? file.LastAccessTime : default
+                            accessTime: includeAccessTime ? file.LastAccessTime : default,
+                            fileAttributes: includeFileAttributes ? file.Attributes.ToString() : ""
                         )
                     );
                 }
             }
             catch  {            }
         }
-        public void FindFilesCrossPlatform(List<string> extensionsToIgnore = null, bool includeFileSize = false, bool includeAccessTime = false, bool verbose = false)
+        public void FindFilesCrossPlatform(List<string> extensionsToIgnore = null, bool includeFileSize = false, bool includeAccessTime = false, bool includeFileAttributes = false, bool verbose = false)
         {
             try
             {
@@ -140,7 +141,8 @@ namespace SMBeagle.FileDiscovery
                                             creationTime: d.CreationTime,
                                             lastWriteTime: d.LastWriteTime,
                                             fileSize: includeFileSize ? (long)d.EndOfFile : 0,
-                                            accessTime: includeAccessTime ? d.LastAccessTime : default
+                                            accessTime: includeAccessTime ? d.LastAccessTime : default,
+                                            fileAttributes: includeFileAttributes ? d.FileAttributes.ToString() : ""
                                         )
                                     );
                                 }
@@ -227,17 +229,17 @@ namespace SMBeagle.FileDiscovery
             }
         }
 
-        public void FindFilesRecursively(bool crossPlatform, ref bool abort, List<string> extensionsToIgnore = null, bool includeFileSize = false, bool includeAccessTime = false, bool verbose = false)
+        public void FindFilesRecursively(bool crossPlatform, ref bool abort, List<string> extensionsToIgnore = null, bool includeFileSize = false, bool includeAccessTime = false, bool includeFileAttributes = false, bool verbose = false)
         {
             if (crossPlatform)
-                FindFilesCrossPlatform(extensionsToIgnore, includeFileSize, includeAccessTime, verbose);
+                FindFilesCrossPlatform(extensionsToIgnore, includeFileSize, includeAccessTime, includeFileAttributes, verbose);
             else
-                FindFilesWindows(extensionsToIgnore, includeFileSize, includeAccessTime, verbose);
+                FindFilesWindows(extensionsToIgnore, includeFileSize, includeAccessTime, includeFileAttributes, verbose);
             foreach (Directory dir in RecursiveChildDirectories)
             {
                 if (abort)
                     return;
-                dir.FindFilesRecursively(crossPlatform, ref abort, extensionsToIgnore, includeFileSize, includeAccessTime, verbose);
+                dir.FindFilesRecursively(crossPlatform, ref abort, extensionsToIgnore, includeFileSize, includeAccessTime, includeFileAttributes, verbose);
             }
         }
 

--- a/FileDiscovery/File.cs
+++ b/FileDiscovery/File.cs
@@ -13,10 +13,11 @@ namespace SMBeagle.FileDiscovery
         public bool Deletable { get; set; }
         public long FileSize { get; set; }
         public DateTime AccessTime { get; set; }
+        public string FileAttributes { get; set; }
         public DateTime CreationTime { get; set; }
         public DateTime LastWriteTime { get; set; }
 
-        public File(string name, string fullName, string extension, DateTime creationTime, DateTime lastWriteTime, Directory parentDirectory, long fileSize = 0, DateTime accessTime = default)
+        public File(string name, string fullName, string extension, DateTime creationTime, DateTime lastWriteTime, Directory parentDirectory, long fileSize = 0, DateTime accessTime = default, string fileAttributes = "")
         {
             Name = name;
             Extension = extension;
@@ -26,6 +27,7 @@ namespace SMBeagle.FileDiscovery
             FullName = fullName;
             FileSize = fileSize;
             AccessTime = accessTime;
+            FileAttributes = fileAttributes;
         }
 
         public void SetPermissions(bool read, bool write, bool delete)

--- a/FileDiscovery/FileFinder.cs
+++ b/FileDiscovery/FileFinder.cs
@@ -48,10 +48,12 @@ namespace SMBeagle.FileDiscovery
 
         bool _includeFileSize;
         bool _includeAccessTime;
-        public FileFinder(List<Share> shares, string outputDirectory, bool fetchFiles, List<String> filePatterns, bool getPermissionsForSingleFileInDir = true, bool enumerateAcls = true, bool quiet = false, bool verbose = false, bool crossPlatform = false, bool includeFileSize = false, bool includeAccessTime = false)
+        bool _includeFileAttributes;
+        public FileFinder(List<Share> shares, string outputDirectory, bool fetchFiles, List<String> filePatterns, bool getPermissionsForSingleFileInDir = true, bool enumerateAcls = true, bool quiet = false, bool verbose = false, bool crossPlatform = false, bool includeFileSize = false, bool includeAccessTime = false, bool includeFileAttributes = false)
         {
             _includeFileSize = includeFileSize;
             _includeAccessTime = includeAccessTime;
+            _includeFileAttributes = includeFileAttributes;
             if (fetchFiles)
             {
                 try
@@ -131,7 +133,7 @@ namespace SMBeagle.FileDiscovery
                 abort = false;
                 OutputHelper.WriteLine($"\renumerating files in '{dir.UNCPath}' - CTRL-BREAK or CTRL-PAUSE to SKIP                                          ", 1, false);
                 // TODO: pass in the ignored extensions from the commandline
-                dir.FindFilesRecursively(crossPlatform: crossPlatform, ref abort, extensionsToIgnore: new List<string>() { ".dll",".manifest",".cat" }, includeFileSize: _includeFileSize, includeAccessTime: _includeAccessTime, verbose: verbose);
+                dir.FindFilesRecursively(crossPlatform: crossPlatform, ref abort, extensionsToIgnore: new List<string>() { ".dll",".manifest",".cat" }, includeFileSize: _includeFileSize, includeAccessTime: _includeAccessTime, includeFileAttributes: _includeFileAttributes, verbose: verbose);
                 if (verbose)
                     OutputHelper.WriteLine($"\rFound {dir.ChildDirectories.Count} child directories and {dir.RecursiveFiles.Count} files in '{dir.UNCPath}'",2);
                 

--- a/FileDiscovery/Output/FileOutput.cs
+++ b/FileDiscovery/Output/FileOutput.cs
@@ -24,6 +24,7 @@ namespace SMBeagle.FileDiscovery.Output
         public string Base { get; set; }
         public long FileSize { get; set; }
         public DateTime AccessTime { get; set; }
+        public string FileAttributes { get; set; }
         public FileOutput(File file)
         {
             Name = file.Name.ToLower();
@@ -39,6 +40,7 @@ namespace SMBeagle.FileDiscovery.Output
             Base = file.ParentDirectory.Share.uncPath;
             FileSize = file.FileSize;
             AccessTime = file.AccessTime;
+            FileAttributes = file.FileAttributes;
         }
     }
 }

--- a/IMPLEMENTATION_REPORT_FILEATTRIBUTES.md
+++ b/IMPLEMENTATION_REPORT_FILEATTRIBUTES.md
@@ -1,0 +1,24 @@
+# Implementation Report --fileattributes
+
+## Analyse Technique Réalisée
+- Confirmé la faisabilité d'obtenir les attributs via `FileInfo.Attributes` sur Windows et `FileDirectoryInformation.FileAttributes` en mode cross‑platform.
+- Les deux APIs exposent une énumération .NET convertie en chaîne avec `ToString()` ; le type `string` est donc approprié pour stocker plusieurs indicateurs (Hidden, ReadOnly…).
+- Les attributs sont simplement ajoutés au modèle `File` et propagés dans l'output CSV sans formatage spécifique.
+
+## Modifications Par Fichier
+- **Program.cs** : ajout de l'option CLI `--fileattributes` et propagation à `FileFinder` (lignes 452‑482 et 330‑342).
+- **FileDiscovery/File.cs** : nouvelle propriété `FileAttributes` et paramètre dans le constructeur (lignes 10‑31).
+- **FileDiscovery/Output/FileOutput.cs** : écriture des attributs dans la sortie (lignes 20‑44).
+- **FileDiscovery/Directory.cs** : collecte conditionnelle des attributs dans les méthodes Windows et cross‑platform, nouveau paramètre récursif (lignes 74‑102, 101‑160, 232‑244).
+- **FileDiscovery/FileFinder.cs** : prise en charge du flag `includeFileAttributes` et passage aux répertoires (lignes 46‑68, 132‑136).
+- **README.md** : documentation du nouvel argument CLI (ligne 155).
+
+## Tests et Validation
+- `dotnet build SMBeagle.csproj` : **succès** avec avertissements.
+- `dotnet run --project SMBeagle.csproj -- --help` : l'option `--fileattributes` apparaît correctement.
+- Exécution de `dotnet run --project SMBeagle.csproj -- --fileattributes -c test.csv -D` : l'application démarre sans erreur.
+
+## Recommandations Architecturales
+- Continuer à regrouper les nouveaux indicateurs dans `FileFinder` pour garder la signature du constructeur cohérente.
+- Prévoir une classe dédiée aux métadonnées afin d'éviter des constructeurs trop longs pour les trois options restantes.
+- Optimiser le logging en factorisant les messages similaires entre méthodes Windows et cross‑platform.

--- a/Program.cs
+++ b/Program.cs
@@ -338,6 +338,7 @@ namespace SMBeagle
                     crossPlatform: crossPlatform
                     , includeFileSize: opts.SizeFile
                     , includeAccessTime: opts.AccessTime
+                    , includeFileAttributes: opts.FileAttributes
                     );
 
             OutputHelper.WriteLine("7. Completing the writes to CSV or elasticsearch (or both)");
@@ -457,6 +458,9 @@ namespace SMBeagle
             [Option("access-time", Required = false, HelpText = "Collect last access time for files")]
             public bool AccessTime { get; set; }
 
+            [Option("fileattributes", Required = false, HelpText = "Collect file system attributes")]
+            public bool FileAttributes { get; set; }
+
             [Usage(ApplicationAlias = "SMBeagle")]
             public static IEnumerable<Example> Examples
             {
@@ -471,6 +475,7 @@ namespace SMBeagle
                     yield return new Example("Do not enumerate ACLs (FASTER)", unParserSettings, new Options { ElasticsearchHost = "127.0.0.1", DontEnumerateAcls = true });
                     yield return new Example("Collect file size metadata", unParserSettings, new Options { ElasticsearchHost = "127.0.0.1", SizeFile = true });
                     yield return new Example("Collect file access time metadata", unParserSettings, new Options { ElasticsearchHost = "127.0.0.1", AccessTime = true });
+                    yield return new Example("Collect file attributes metadata", unParserSettings, new Options { ElasticsearchHost = "127.0.0.1", FileAttributes = true });
                 }
             }
         }

--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ Do not enumerate ACLs (FASTER):
                                      ACLs
   --sizefile                         Collect file sizes in bytes
   --access-time                      Collect last access time for files
+  --fileattributes                   Collect file system attributes
   -d, --domain                       (Default: ) Domain for connecting to SMB
   -u, --username                     Username for connecting to SMB - mandatory
                                      on linux


### PR DESCRIPTION
## Summary
- add `--fileattributes` option in Program.cs
- capture file attributes in Directory and propagate through FileFinder
- store the attributes in File model and output
- document the new option
- add implementation report for the feature

## Testing
- `dotnet build SMBeagle.csproj -v minimal`
- `dotnet run --project SMBeagle.csproj -- --help`
- `dotnet run --project SMBeagle.csproj -- --fileattributes -c test.csv -D`

------
https://chatgpt.com/codex/tasks/task_e_6851570dca3083208ae5244e6c956452