### PR TITLE
Fix CSV deduplication bug

### DIFF
--- a/FileDiscovery/Directory.cs
+++ b/FileDiscovery/Directory.cs
@@ -97,7 +97,7 @@ namespace SMBeagle.FileDiscovery
             Share = share;
             Path = path;
         }
-        public void FindFilesWindows(List<string> extensionsToIgnore = null, bool includeFileSize = false, bool includeAccessTime = false, bool includeFileAttributes = false, bool includeFileOwner = false, bool includeFastHash = false, bool includeFileSignature = false, bool verbose = false, HashSet<string> dedupSet = null)
+        public void FindFilesWindows(List<string> extensionsToIgnore = null, bool includeFileSize = false, bool includeAccessTime = false, bool includeFileAttributes = false, bool includeFileOwner = false, bool includeFastHash = false, bool includeFileSignature = false, bool verbose = false)
         {
             try
             {
@@ -107,9 +107,6 @@ namespace SMBeagle.FileDiscovery
                 foreach (FileInfo file in files)
                 {
                     if (extensionsToIgnore.Contains(file.Extension.ToLower()))
-                        continue;
-                    string fileKey = $"{Share.uncPath}{file.FullName}".ToLower();
-                    if (dedupSet != null && !dedupSet.Add(fileKey))
                         continue;
                     string owner = string.Empty;
 #pragma warning disable CA1416
@@ -138,7 +135,7 @@ namespace SMBeagle.FileDiscovery
             }
             catch  {            }
         }
-        public void FindFilesCrossPlatform(List<string> extensionsToIgnore = null, bool includeFileSize = false, bool includeAccessTime = false, bool includeFileAttributes = false, bool includeFileOwner = false, bool includeFastHash = false, bool includeFileSignature = false, bool verbose = false, HashSet<string> dedupSet = null)
+        public void FindFilesCrossPlatform(List<string> extensionsToIgnore = null, bool includeFileSize = false, bool includeAccessTime = false, bool includeFileAttributes = false, bool includeFileOwner = false, bool includeFastHash = false, bool includeFileSignature = false, bool verbose = false)
         {
             try
             {
@@ -170,9 +167,6 @@ namespace SMBeagle.FileDiscovery
                                     else
                                         path = $"{Path}\\{d.FileName}";
                                     if (extensionsToIgnore.Contains(extension.ToLower()))
-                                        continue;
-                                    string fileKey = $"{Share.uncPath}{path}".ToLower();
-                                    if (dedupSet != null && !dedupSet.Add(fileKey))
                                         continue;
                                     string owner = includeFileOwner ? "<NOT_SUPPORTED>" : string.Empty;
                                     string fastHash = includeFastHash ? CrossPlatformHelper.ComputeFastHash(fileStore, path) : string.Empty;
@@ -277,16 +271,16 @@ namespace SMBeagle.FileDiscovery
             }
         }
 
-        public void FindFilesRecursively(bool crossPlatform, ref bool abort, List<string> extensionsToIgnore = null, bool includeFileSize = false, bool includeAccessTime = false, bool includeFileAttributes = false, bool includeFileOwner = false, bool includeFastHash = false, bool includeFileSignature = false, bool verbose = false, HashSet<string> dedupSet = null)
+        public void FindFilesRecursively(bool crossPlatform, ref bool abort, List<string> extensionsToIgnore = null, bool includeFileSize = false, bool includeAccessTime = false, bool includeFileAttributes = false, bool includeFileOwner = false, bool includeFastHash = false, bool includeFileSignature = false, bool verbose = false)
         {
             if (verbose)
             {
                 OutputHelper.WriteLine($"Processing directory: {UNCPath}", 3);
             }
             if (crossPlatform)
-                FindFilesCrossPlatform(extensionsToIgnore, includeFileSize, includeAccessTime, includeFileAttributes, includeFileOwner, includeFastHash, includeFileSignature, verbose, dedupSet);
+                FindFilesCrossPlatform(extensionsToIgnore, includeFileSize, includeAccessTime, includeFileAttributes, includeFileOwner, includeFastHash, includeFileSignature, verbose);
             else
-                FindFilesWindows(extensionsToIgnore, includeFileSize, includeAccessTime, includeFileAttributes, includeFileOwner, includeFastHash, includeFileSignature, verbose, dedupSet);
+                FindFilesWindows(extensionsToIgnore, includeFileSize, includeAccessTime, includeFileAttributes, includeFileOwner, includeFastHash, includeFileSignature, verbose);
             // Iterate only direct children here. Using RecursiveChildDirectories
             // caused repeated traversal of the same subdirectories at every level,
             // dramatically impacting performance when verbose access-time logging
@@ -295,7 +289,7 @@ namespace SMBeagle.FileDiscovery
             {
                 if (abort)
                     return;
-                dir.FindFilesRecursively(crossPlatform, ref abort, extensionsToIgnore, includeFileSize, includeAccessTime, includeFileAttributes, includeFileOwner, includeFastHash, includeFileSignature, verbose, dedupSet);
+                dir.FindFilesRecursively(crossPlatform, ref abort, extensionsToIgnore, includeFileSize, includeAccessTime, includeFileAttributes, includeFileOwner, includeFastHash, includeFileSignature, verbose);
             }
         }
 

--- a/FileDiscovery/FileFinder.cs
+++ b/FileDiscovery/FileFinder.cs
@@ -152,7 +152,7 @@ namespace SMBeagle.FileDiscovery
                 abort = false;
                 OutputHelper.WriteLine($"\renumerating files in '{dir.UNCPath}' - CTRL-BREAK or CTRL-PAUSE to SKIP                                          ", 1, false);
                 // TODO: pass in the ignored extensions from the commandline
-                dir.FindFilesRecursively(crossPlatform: crossPlatform, ref abort, extensionsToIgnore: new List<string>() { ".dll",".manifest",".cat" }, includeFileSize: _includeFileSize, includeAccessTime: _includeAccessTime, includeFileAttributes: _includeFileAttributes, includeFileOwner: _includeFileOwner, includeFastHash: _includeFastHash, includeFileSignature: _includeFileSignature, verbose: verbose, dedupSet: FilesSentForOutput);
+                dir.FindFilesRecursively(crossPlatform: crossPlatform, ref abort, extensionsToIgnore: new List<string>() { ".dll",".manifest",".cat" }, includeFileSize: _includeFileSize, includeAccessTime: _includeAccessTime, includeFileAttributes: _includeFileAttributes, includeFileOwner: _includeFileOwner, includeFastHash: _includeFastHash, includeFileSignature: _includeFileSignature, verbose: verbose);
                 if (verbose)
                     OutputHelper.WriteLine($"\rFound {dir.ChildDirectories.Count} child directories and {dir.RecursiveFiles.Count} files in '{dir.UNCPath}'",2);
                 


### PR DESCRIPTION
## Summary
- remove early deduplication that prevented file output
- update recursive file enumeration without dedup set

## Testing
- `dotnet build --configuration Release` *(fails: command not found)*
- `bin/Release/net9.0/linux-x64/SMBeagle --help`
- `bin/Release/net9.0/linux-x64/SMBeagle -l -c test.csv --sizefile -v`

------
https://chatgpt.com/codex/tasks/task_e_6852662b05808320ac97056c951bb4ed