### PR TITLE
Implement --local-path scanning

### DIFF
--- a/FileDiscovery/LocalHelper.cs
+++ b/FileDiscovery/LocalHelper.cs
@@ -1,0 +1,68 @@
+using System;
+using System.IO;
+using System.IO.Hashing;
+using System.Runtime.InteropServices;
+
+namespace SMBeagle.FileDiscovery
+{
+    static class LocalHelper
+    {
+        public static ACL ResolvePermissions(string path)
+        {
+            ACL acl = new();
+            try { new FileStream(path, FileMode.Open, FileAccess.Read).Dispose(); acl.Readable = true; } catch { }
+            try { new FileStream(path, FileMode.Open, FileAccess.Write).Dispose(); acl.Writeable = true; } catch { }
+            // Deletion test is not performed for safety
+            return acl;
+        }
+
+        public static string ComputeFastHash(string filePath)
+        {
+            const int READ_SIZE = 65536;
+            try
+            {
+                using FileStream fs = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+                int toRead = (int)Math.Min(READ_SIZE, fs.Length);
+                byte[] buffer = new byte[toRead];
+                int read = fs.Read(buffer, 0, toRead);
+                ulong hash = XxHash64.HashToUInt64(buffer.AsSpan(0, read));
+                return hash.ToString("x16");
+            }
+            catch
+            {
+                return string.Empty;
+            }
+        }
+
+        public static string DetectFileSignature(string filePath)
+        {
+            const int READ_SIZE = 32;
+            try
+            {
+                using FileStream fs = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+                int toRead = (int)Math.Min(READ_SIZE, fs.Length);
+                byte[] buffer = new byte[toRead];
+                int read = fs.Read(buffer, 0, toRead);
+                using MemoryStream ms = new MemoryStream(buffer, 0, read);
+                var inspector = new FileSignatures.FileFormatInspector();
+                var format = inspector.DetermineFileFormat(ms);
+                return format == null ? "unknown" : format.Extension.TrimStart('.').ToLower();
+            }
+            catch
+            {
+                return string.Empty;
+            }
+        }
+
+        public static string GetFileOwner(string filePath)
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+#pragma warning disable CA1416
+                return WindowsHelper.GetFileOwner(filePath);
+#pragma warning restore CA1416
+            }
+            return "<NOT_SUPPORTED>";
+        }
+    }
+}

--- a/IMPLEMENTATION_REPORT_LOCAL_PATH.md
+++ b/IMPLEMENTATION_REPORT_LOCAL_PATH.md
@@ -1,0 +1,24 @@
+# Implementation Report --local-path
+
+## Approche Architecturale Choisie
+- [x] Extension FileFinder avec objets dummy Share/Host
+- [ ] Nouveau constructeur FileFinder
+- La fonctionnalité --local-path s'appuie sur des répertoires locaux représentés par un Share "LOCAL_SCAN" associé à l'hôte fictif "localhost". Les méthodes de FileFinder détectent ce mode et utilisent des appels système locaux.
+
+## Modifications Détaillées Par Fichier
+- **Program.cs** : ajout de l'option `local-path` et traitement dédié avant toute découverte réseau.
+- **FileFinder.cs** : prise en charge du mode local via `_localScan`, création de répertoires locaux, nouvelles méthodes `FetchFilePermissionLocal` et `FetchFileLocal`.
+- **Directory.cs** : adaptation de `UNCPath`, ajout des méthodes `FindFilesLocal` et `FindDirectoriesLocal`, prise en charge du mode local dans les récursions.
+- **LocalHelper.cs** : nouveaux utilitaires cross‑platform pour le calcul de hash, la détection de signature et la résolution de permissions locales.
+
+## Tests de Validation Réalisés
+- `dotnet build` *(échec : SDK .NET 9 manquant)*
+- `dotnet run -- --help` *(non exécuté à cause de l'échec build)*
+
+## Performance et Comportement
+- Le scan local évite toute latence réseau et utilise `System.IO` pour l'énumération.
+
+## Recommandations Futures
+- Installer le SDK .NET 9 pour pouvoir compiler et tester intégralement.
+- Étendre la résolution des ACLs pour Linux via `Mono.Posix`.
+- Ajouter des tests unitaires sur les nouvelles fonctionnalités.


### PR DESCRIPTION
## Summary
- add new `--local-path` CLI option
- extend Program.cs logic to launch local scans
- support local directories in FileFinder and Directory classes
- implement LocalHelper for cross-platform filesystem operations
- document implementation details

## Testing
- `dotnet build SMBeagle.sln --configuration Release` *(fails: .NET 9 SDK missing)*
- `dotnet run -- --help` *(fails due to build error)*

------
https://chatgpt.com/codex/tasks/task_e_68547e259d148320b738de86698762da