### PR TITLE
Enhance --local-path with Linux ACL support and verbose logs

### DIFF
--- a/FileDiscovery/LocalHelper.cs
+++ b/FileDiscovery/LocalHelper.cs
@@ -2,21 +2,45 @@ using System;
 using System.IO;
 using System.IO.Hashing;
 using System.Runtime.InteropServices;
+using Mono.Unix;
 
 namespace SMBeagle.FileDiscovery
 {
     static class LocalHelper
     {
-        public static ACL ResolvePermissions(string path)
+        public static ACL ResolvePermissions(string path, bool verbose = false)
         {
             ACL acl = new();
-            try { new FileStream(path, FileMode.Open, FileAccess.Read).Dispose(); acl.Readable = true; } catch { }
-            try { new FileStream(path, FileMode.Open, FileAccess.Write).Dispose(); acl.Writeable = true; } catch { }
-            // Deletion test is not performed for safety
-            return acl;
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                try { new FileStream(path, FileMode.Open, FileAccess.Read).Dispose(); acl.Readable = true; } catch { }
+                try { new FileStream(path, FileMode.Open, FileAccess.Write).Dispose(); acl.Writeable = true; } catch { }
+                return acl;
+            }
+            else
+            {
+                try
+                {
+                    var fileInfo = new UnixFileInfo(path);
+                    FileAccessPermissions perms = fileInfo.FileAccessPermissions;
+                    acl.Readable = (perms & (FileAccessPermissions.UserRead | FileAccessPermissions.GroupRead | FileAccessPermissions.OtherRead)) != 0;
+                    acl.Writeable = (perms & (FileAccessPermissions.UserWrite | FileAccessPermissions.GroupWrite | FileAccessPermissions.OtherWrite)) != 0;
+                    var dirInfo = new UnixDirectoryInfo(Path.GetDirectoryName(path));
+                    acl.Deletable = (dirInfo.FileAccessPermissions & FileAccessPermissions.UserWrite) != 0;
+                    if (verbose)
+                        Output.OutputHelper.WriteLine($"[LOCAL-ACL] Linux permissions R:{acl.Readable}/W:{acl.Writeable}/D:{acl.Deletable} for {Path.GetFileName(path)}",3);
+                }
+                catch (Exception ex)
+                {
+                    if (verbose)
+                        Output.OutputHelper.WriteLine($"[LOCAL-ACL] Error getting Linux permissions for {Path.GetFileName(path)}: {ex.Message}",3);
+                    acl.Readable = File.Exists(path);
+                }
+                return acl;
+            }
         }
 
-        public static string ComputeFastHash(string filePath)
+        public static string ComputeFastHash(string filePath, bool verbose = false)
         {
             const int READ_SIZE = 65536;
             try
@@ -26,15 +50,37 @@ namespace SMBeagle.FileDiscovery
                 byte[] buffer = new byte[toRead];
                 int read = fs.Read(buffer, 0, toRead);
                 ulong hash = XxHash64.HashToUInt64(buffer.AsSpan(0, read));
+                if (verbose)
+                    Output.OutputHelper.WriteLine($"[LOCAL-HASH] Computed hash for: {Path.GetFileName(filePath)}",3);
                 return hash.ToString("x16");
             }
-            catch
+            catch (UnauthorizedAccessException)
             {
-                return string.Empty;
+                if (verbose)
+                    Output.OutputHelper.WriteLine($"[LOCAL-HASH] Access denied: {Path.GetFileName(filePath)}",3);
+                return "<ACCESS_DENIED>";
+            }
+            catch (FileNotFoundException)
+            {
+                if (verbose)
+                    Output.OutputHelper.WriteLine($"[LOCAL-HASH] File not found: {Path.GetFileName(filePath)}",3);
+                return "<FILE_NOT_FOUND>";
+            }
+            catch (IOException ex)
+            {
+                if (verbose)
+                    Output.OutputHelper.WriteLine($"[LOCAL-HASH] I/O error for {Path.GetFileName(filePath)}: {ex.Message}",3);
+                return "<IO_ERROR>";
+            }
+            catch (Exception ex)
+            {
+                if (verbose)
+                    Output.OutputHelper.WriteLine($"[LOCAL-HASH] Unexpected error for {Path.GetFileName(filePath)}: {ex.GetType().Name}",3);
+                return $"<ERROR_{ex.GetType().Name}>";
             }
         }
 
-        public static string DetectFileSignature(string filePath)
+        public static string DetectFileSignature(string filePath, bool verbose = false)
         {
             const int READ_SIZE = 32;
             try
@@ -46,15 +92,38 @@ namespace SMBeagle.FileDiscovery
                 using MemoryStream ms = new MemoryStream(buffer, 0, read);
                 var inspector = new FileSignatures.FileFormatInspector();
                 var format = inspector.DetermineFileFormat(ms);
-                return format == null ? "unknown" : format.Extension.TrimStart('.').ToLower();
+                string result = format == null ? "unknown" : format.Extension.TrimStart('.').ToLower();
+                if (verbose)
+                    Output.OutputHelper.WriteLine($"[LOCAL-SIGN] Signature for {Path.GetFileName(filePath)}: {result}",3);
+                return result;
             }
-            catch
+            catch (UnauthorizedAccessException)
             {
-                return string.Empty;
+                if (verbose)
+                    Output.OutputHelper.WriteLine($"[LOCAL-SIGN] Access denied: {Path.GetFileName(filePath)}",3);
+                return "<ACCESS_DENIED>";
+            }
+            catch (FileNotFoundException)
+            {
+                if (verbose)
+                    Output.OutputHelper.WriteLine($"[LOCAL-SIGN] File not found: {Path.GetFileName(filePath)}",3);
+                return "<FILE_NOT_FOUND>";
+            }
+            catch (IOException ex)
+            {
+                if (verbose)
+                    Output.OutputHelper.WriteLine($"[LOCAL-SIGN] I/O error for {Path.GetFileName(filePath)}: {ex.Message}",3);
+                return "<IO_ERROR>";
+            }
+            catch (Exception ex)
+            {
+                if (verbose)
+                    Output.OutputHelper.WriteLine($"[LOCAL-SIGN] Unexpected error for {Path.GetFileName(filePath)}: {ex.GetType().Name}",3);
+                return $"<ERROR_{ex.GetType().Name}>";
             }
         }
 
-        public static string GetFileOwner(string filePath)
+        public static string GetFileOwner(string filePath, bool verbose = false)
         {
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
@@ -62,7 +131,22 @@ namespace SMBeagle.FileDiscovery
                 return WindowsHelper.GetFileOwner(filePath);
 #pragma warning restore CA1416
             }
-            return "<NOT_SUPPORTED>";
+            try
+            {
+                var fileInfo = new UnixFileInfo(filePath);
+                var ownerInfo = fileInfo.OwnerUser;
+                var groupInfo = fileInfo.OwnerGroup;
+                string result = $"{ownerInfo.UserName}:{groupInfo.GroupName}";
+                if (verbose)
+                    Output.OutputHelper.WriteLine($"[LOCAL-OWNER] Linux owner: {result} for {Path.GetFileName(filePath)}",3);
+                return result;
+            }
+            catch (Exception ex)
+            {
+                if (verbose)
+                    Output.OutputHelper.WriteLine($"[LOCAL-OWNER] Error getting Linux owner for {Path.GetFileName(filePath)}: {ex.Message}",3);
+                return $"<LINUX_ERROR_{ex.GetType().Name}>";
+            }
         }
     }
 }

--- a/IMPLEMENTATION_REPORT_LOCAL_PATH_IMPROVED.md
+++ b/IMPLEMENTATION_REPORT_LOCAL_PATH_IMPROVED.md
@@ -1,0 +1,32 @@
+# Implementation Report --local-path Enhanced
+
+## Diagnostic Initial Confirmé
+- Option `--local-path` existante mais jamais testée
+- Gestion d'erreurs minimaliste dans `LocalHelper`
+- ACLs Linux non implémentées
+
+## Améliorations Appliquées
+### 1. Gestion d'Erreurs Robuste
+- Toutes les méthodes de `LocalHelper` acceptent un paramètre `verbose` et renvoient des codes d'erreur explicites
+- Journalisation détaillée `[LOCAL-*]` ajoutée
+
+### 2. ACLs Linux Natives
+- Ajout du package `Mono.Posix.NETStandard`
+- Utilisation de `UnixFileInfo` et `UnixDirectoryInfo` pour détecter permissions et propriétaire
+
+### 3. Logging et Debug
+- Verbosité étendue dans `FindFilesLocal`, `FindDirectoriesLocal` et validation des chemins
+- Méthode `GetLocalPathDirectories` vérifie et normalise les chemins
+
+## Tests de Validation Exécutés
+- `dotnet build --configuration Release` *(échec : SDK .NET 9 manquant)*
+- `dotnet run -- --help` *(non exécuté à cause de l'échec précédent)*
+- Tentative de scan local sur `/tmp/smbeagle_test` *(non exécuté)*
+
+## Recommandations Production
+- Installer le SDK .NET 9 pour compiler
+- Ajouter des tests unitaires couvrant les nouveaux messages d'erreur
+- Surveiller la performance sur de très grands volumes
+
+## Impact Performance
+- N/A (tests de performance non réalisés)

--- a/SMBeagle.csproj
+++ b/SMBeagle.csproj
@@ -39,6 +39,7 @@
     <PackageReference Include="SMBLibrary" Version="1.5.3.5" />
     <PackageReference Include="System.IO.FileSystem.AccessControl" Version="5.0.0" />
     <PackageReference Include="System.IO.Hashing" Version="9.0.0" />
+    <PackageReference Include="Mono.Posix.NETStandard" Version="5.20.1-preview" />
   </ItemGroup>
 
   <!-- PROTECTION APIs Windows pour ownerfile -->


### PR DESCRIPTION
## Summary
- implement robust error handling and verbose logging in `LocalHelper`
- add Linux ACL and owner detection using Mono.Posix
- improve local directory validation in `FileFinder`
- add verbose support for local directory enumeration
- document the implementation

## Testing
- `dotnet build --configuration Release` *(fails: NETSDK1045)*
- `dotnet run -- --help` *(fails: build failed)*

------
https://chatgpt.com/codex/tasks/task_e_68548504a50c8320a77cbc7d2b7855b4